### PR TITLE
a possible implementation to enable local drand

### DIFF
--- a/build/drand.go
+++ b/build/drand.go
@@ -2,6 +2,7 @@ package build
 
 import (
 	"sort"
+	"os"
 
 	"github.com/filecoin-project/lotus/node/modules/dtypes"
 )
@@ -30,22 +31,23 @@ const (
 	DrandQuicknet
 )
 
+func getDrandChainInfo() string {
+	b, _ := os.ReadFile(os.Getenv("DRAND_CHAIN_INFO"))
+	str := string(b)
+	return str
+}
+
 var DrandConfigs = map[DrandEnum]dtypes.DrandConfig{
 	DrandMainnet: {
 		Servers: []string{
-			"https://api.drand.sh",
-			"https://api2.drand.sh",
-			"https://api3.drand.sh",
-			"https://drand.cloudflare.com",
-			"https://api.drand.secureweb3.com:6875", // Storswift
+			"http://drand-1",
+			"http://drand-2",
+			"http://drand-3",
 		},
 		Relays: []string{
-			"/dnsaddr/api.drand.sh/",
-			"/dnsaddr/api2.drand.sh/",
-			"/dnsaddr/api3.drand.sh/",
 		},
 		IsChained:     true,
-		ChainInfoJSON: `{"public_key":"868f005eb8e6e4ca0a47c8a77ceaa5309a47978a7c71bc5cce96366b5d7a569937c529eeda66c7293784a9402801af31","period":30,"genesis_time":1595431050,"hash":"8990e7a9aaed2ffed73dbd7092123d6f289930540d7651336225dc172e51b2ce","groupHash":"176f93498eac9ca337150b46d21dd58673ea4e3581185f869672e59fa4cb390a"}`,
+		ChainInfoJSON: getDrandChainInfo(),
 	},
 	DrandQuicknet: {
 		Servers: []string{


### PR DESCRIPTION
## Related Issues
we can't run lotus in a disconnected, isolated environment since it expects to be able to access the drand service as a distributed source of entropy. This patch allows us to pass the chain info from a locally running drand service. The drand endpoints could also be provided with environment variables, though, in this implementation the endpoints are fixed strings representing locally controlled hostnames.

## Proposed Changes
add en environment variable DRAND_CHAIN_INFO which contains json formatted chain info from drand
add fixed string hostnames for a locally controlled drand network - a better approach would be to allow setting the endpoints via environment variable (not implemented in this PR)